### PR TITLE
Update github.com/segmentio/encoding to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/mattn/go-colorable v0.1.2 // indirect
 	github.com/mattn/go-isatty v0.0.9 // indirect
 	github.com/pquerna/ffjson v0.0.0-20190930134022-aa0246cd15f7
-	github.com/segmentio/encoding v0.1.0
+	github.com/segmentio/encoding v0.1.14
 	github.com/stretchr/testify v1.4.0
 	github.com/tidwall/pretty v1.0.0 // indirect
 	github.com/ugorji/go/codec v1.1.7

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pquerna/ffjson v0.0.0-20190930134022-aa0246cd15f7 h1:xoIK0ctDddBMnc74udxJYBqlo9Ylnsp1waqjLsnef20=
 github.com/pquerna/ffjson v0.0.0-20190930134022-aa0246cd15f7/go.mod h1:YARuvh7BUWHNhzDq2OM5tzR2RiCcN2D7sapiKyCel/M=
-github.com/segmentio/encoding v0.1.0 h1:V/FrZFA2Fm4Hpk3JdA+3JWN6fJnp15dZOnB+CI3Wcbw=
-github.com/segmentio/encoding v0.1.0/go.mod h1:RWhr02uzMB9gQC1x+MfYxedtmBibb9cZ6Vv9VxRSSbw=
+github.com/segmentio/encoding v0.1.14 h1:BfnglNbNRohLaBLf93uP5/IwKqeWrezXK/g6IRnj75c=
+github.com/segmentio/encoding v0.1.14/go.mod h1:RWhr02uzMB9gQC1x+MfYxedtmBibb9cZ6Vv9VxRSSbw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=

--- a/vendor/github.com/segmentio/encoding/ascii/valid.go
+++ b/vendor/github.com/segmentio/encoding/ascii/valid.go
@@ -1,19 +1,86 @@
 package ascii
 
-import "unsafe"
+import (
+	"unsafe"
+)
 
-// Valid retuns true if b contains only ASCII characters.
+// Valid returns true if b contains only ASCII characters.
 func Valid(b []byte) bool {
 	return valid(unsafe.Pointer(&b), uintptr(len(b)))
 }
 
-// Valid retuns true if s contains only ASCII characters.
+// ValidString returns true if s contains only ASCII characters.
 func ValidString(s string) bool {
 	return valid(unsafe.Pointer(&s), uintptr(len(s)))
 }
 
+// ValidBytes returns true if b is an ASCII character.
+func ValidByte(b byte) bool {
+	return b <= 0x7f
+}
+
+// ValidBytes returns true if b is an ASCII character.
+func ValidRune(r rune) bool {
+	return r <= 0x7f
+}
+
 //go:nosplit
 func valid(s unsafe.Pointer, n uintptr) bool {
+	i := uintptr(0)
+	p := *(*unsafe.Pointer)(s)
+
+	for n >= 8 {
+		if ((*(*uint64)(unsafe.Pointer(uintptr(p) + i))) & 0x8080808080808080) != 0 {
+			return false
+		}
+		i += 8
+		n -= 8
+	}
+
+	if n >= 4 {
+		if ((*(*uint32)(unsafe.Pointer(uintptr(p) + i))) & 0x80808080) != 0 {
+			return false
+		}
+		i += 4
+		n -= 4
+	}
+
+	var x uint32
+	switch n {
+	case 3:
+		x = uint32(*(*uint8)(unsafe.Pointer(uintptr(p) + i))) | uint32(*(*uint16)(unsafe.Pointer(uintptr(p) + i + 1)))<<8
+	case 2:
+		x = uint32(*(*uint16)(unsafe.Pointer(uintptr(p) + i)))
+	case 1:
+		x = uint32(*(*uint8)(unsafe.Pointer(uintptr(p) + i)))
+	default:
+		return true
+	}
+	return (x & 0x80808080) == 0
+}
+
+// Valid returns true if b contains only printable ASCII characters.
+func ValidPrint(b []byte) bool {
+	return validPrint(unsafe.Pointer(&b), uintptr(len(b)))
+}
+
+// ValidString returns true if s contains only printable ASCII characters.
+func ValidPrintString(s string) bool {
+	return validPrint(unsafe.Pointer(&s), uintptr(len(s)))
+}
+
+// ValidBytes returns true if b is an ASCII character.
+func ValidPrintByte(b byte) bool {
+	return 0x20 <= b && b <= 0x7e
+}
+
+// ValidBytes returns true if b is an ASCII character.
+func ValidPrintRune(r rune) bool {
+	return 0x20 <= r && r <= 0x7e
+}
+
+//go:nosplit
+func validPrint(s unsafe.Pointer, n uintptr) bool {
 	if n == 0 {
 		return true
 	}
@@ -22,31 +89,66 @@ func valid(s unsafe.Pointer, n uintptr) bool {
 	p := *(*unsafe.Pointer)(s)
 
 	for (n - i) >= 8 {
-		if ((*(*uint64)(unsafe.Pointer(uintptr(p) + i))) & 0x8080808080808080) != 0 {
+		x := *(*uint64)(unsafe.Pointer(uintptr(p) + i))
+		if hasLess64(x, 0x20) || hasMore64(x, 0x7e) {
 			return false
 		}
 		i += 8
 	}
 
 	if (n - i) >= 4 {
-		if ((*(*uint32)(unsafe.Pointer(uintptr(p) + i))) & 0x80808080) != 0 {
+		x := *(*uint32)(unsafe.Pointer(uintptr(p) + i))
+		if hasLess32(x, 0x20) || hasMore32(x, 0x7e) {
 			return false
 		}
 		i += 4
 	}
 
-	if (n - i) >= 2 {
-		if ((*(*uint16)(unsafe.Pointer(uintptr(p) + i))) & 0x8080) != 0 {
-			return false
-		}
-		i += 2
+	var x uint32
+	switch n - i {
+	case 3:
+		x = 0x20000000 | uint32(*(*uint8)(unsafe.Pointer(uintptr(p) + i))) | uint32(*(*uint16)(unsafe.Pointer(uintptr(p) + i + 1)))<<8
+	case 2:
+		x = 0x20200000 | uint32(*(*uint16)(unsafe.Pointer(uintptr(p) + i)))
+	case 1:
+		x = 0x20202000 | uint32(*(*uint8)(unsafe.Pointer(uintptr(p) + i)))
+	default:
+		return true
 	}
+	return !(hasLess32(x, 0x20) || hasMore32(x, 0x7e))
+}
 
-	if (n - i) >= 1 {
-		if ((*(*uint8)(unsafe.Pointer(uintptr(p) + i))) & 0x80) != 0 {
-			return false
-		}
-	}
+// https://graphics.stanford.edu/~seander/bithacks.html#HasLessInWord
+const (
+	hasLessConstL64 = (^uint64(0)) / 255
+	hasLessConstR64 = hasLessConstL64 * 128
 
-	return true
+	hasLessConstL32 = (^uint32(0)) / 255
+	hasLessConstR32 = hasLessConstL32 * 128
+
+	hasMoreConstL64 = (^uint64(0)) / 255
+	hasMoreConstR64 = hasMoreConstL64 * 128
+
+	hasMoreConstL32 = (^uint32(0)) / 255
+	hasMoreConstR32 = hasMoreConstL32 * 128
+)
+
+//go:nosplit
+func hasLess64(x, n uint64) bool {
+	return ((x - (hasLessConstL64 * n)) & ^x & hasLessConstR64) != 0
+}
+
+//go:nosplit
+func hasLess32(x, n uint32) bool {
+	return ((x - (hasLessConstL32 * n)) & ^x & hasLessConstR32) != 0
+}
+
+//go:nosplit
+func hasMore64(x, n uint64) bool {
+	return (((x + (hasMoreConstL64 * (127 - n))) | x) & hasMoreConstR64) != 0
+}
+
+//go:nosplit
+func hasMore32(x, n uint32) bool {
+	return (((x + (hasMoreConstL32 * (127 - n))) | x) & hasMoreConstR32) != 0
 }

--- a/vendor/github.com/segmentio/encoding/json/README.md
+++ b/vendor/github.com/segmentio/encoding/json/README.md
@@ -1,4 +1,4 @@
-# encoding/json
+# encoding/json [![GoDoc](https://godoc.org/github.com/segmentio/encoding/json?status.svg)](https://godoc.org/github.com/segmentio/encoding/json)
 
 Go package offering a replacement implementation of the standard library's
 [`encoding/json`](https://golang.org/pkg/encoding/json/) package, with much
@@ -49,4 +49,28 @@ need it you're better off sticking to the standard library, or spend a bit of
 time implementing it in here ;)
 
 Note that none of those features should result in performance degradations if
-they were implemented in the package.
+they were implemented in the package, and we welcome contributions!
+
+## Trade-offs
+
+As one would expect, we had to make a couple of trade-offs to achieve greater
+performance than the standard library, but there were also features that we
+did not want to give away.
+
+Other open-source packages offering a reduced CPU and memory footprint usually
+do so by designing a different API, or require code generation (therefore adding
+complexity to the build process). These were not acceptable conditions for us,
+as we were not willing to trade off developer productivity for better runtime
+performance. To achieve this, we chose to exactly replicate the standard
+library interfaces and behavior, which meant the package implementation was the
+only area that we were able to work with. The internals of this package make
+heavy use of unsafe pointer arithmetics and other performance optimizations,
+and therefore are not as approachable as typical Go programs. Basically, we put
+a bigger burden on maintainers to achieve better runtime cost without
+sacrificing developer productivity.
+
+For these reasons, we also don't believe that this code should be ported upsteam
+to the standard `encoding/json` package. The standard library has to remain
+readable and approachable to maximize stability and maintainability, and make
+projects like this one possible because a high quality reference implementation
+already exists.

--- a/vendor/github.com/segmentio/encoding/json/codec.go
+++ b/vendor/github.com/segmentio/encoding/json/codec.go
@@ -59,7 +59,7 @@ func typeid(t reflect.Type) unsafe.Pointer {
 }
 
 func constructCachedCodec(t reflect.Type, cache map[unsafe.Pointer]codec) codec {
-	c := constructCodec(t, map[reflect.Type]*structType{})
+	c := constructCodec(t, map[reflect.Type]*structType{}, t.Kind() == reflect.Ptr)
 
 	if inlined(t) {
 		c.encode = constructInlineValueEncodeFunc(c.encode)
@@ -69,7 +69,7 @@ func constructCachedCodec(t reflect.Type, cache map[unsafe.Pointer]codec) codec 
 	return c
 }
 
-func constructCodec(t reflect.Type, seen map[reflect.Type]*structType) (c codec) {
+func constructCodec(t reflect.Type, seen map[reflect.Type]*structType, canAddr bool) (c codec) {
 	switch t {
 	case nullType, nil:
 		c = codec{encode: encoder.encodeNull, decode: decoder.decodeNull}
@@ -155,8 +155,11 @@ func constructCodec(t reflect.Type, seen map[reflect.Type]*structType) (c codec)
 	case reflect.String:
 		c = codec{encode: encoder.encodeString, decode: decoder.decodeString}
 
+	case reflect.Interface:
+		c = constructInterfaceCodec(t)
+
 	case reflect.Array:
-		c = constructArrayCodec(t, seen)
+		c = constructArrayCodec(t, seen, canAddr)
 
 	case reflect.Slice:
 		c = constructSliceCodec(t, seen)
@@ -165,35 +168,36 @@ func constructCodec(t reflect.Type, seen map[reflect.Type]*structType) (c codec)
 		c = constructMapCodec(t, seen)
 
 	case reflect.Struct:
-		c = constructStructCodec(t, seen)
+		c = constructStructCodec(t, seen, canAddr)
 
 	case reflect.Ptr:
 		c = constructPointerCodec(t, seen)
 
 	default:
-		c = constructUnmarshalTypeErrorCodec(t)
+		c = constructUnsupportedTypeCodec(t)
 	}
 
 	p := reflect.PtrTo(t)
 
+	if canAddr {
+		switch {
+		case p.Implements(jsonMarshalerType):
+			c.encode = constructJSONMarshalerEncodeFunc(t, true)
+		case p.Implements(textMarshalerType):
+			c.encode = constructTextMarshalerEncodeFunc(t, true)
+		}
+	}
+
 	switch {
 	case t.Implements(jsonMarshalerType):
 		c.encode = constructJSONMarshalerEncodeFunc(t, false)
-
-	case p.Implements(jsonMarshalerType):
-		c.encode = constructJSONMarshalerEncodeFunc(t, true)
-
 	case t.Implements(textMarshalerType):
 		c.encode = constructTextMarshalerEncodeFunc(t, false)
-
-	case p.Implements(textMarshalerType):
-		c.encode = constructTextMarshalerEncodeFunc(t, true)
 	}
 
 	switch {
 	case p.Implements(jsonUnmarshalerType):
 		c.decode = constructJSONUnmarshalerDecodeFunc(t, true)
-
 	case p.Implements(textUnmarshalerType):
 		c.decode = constructTextUnmarshalerDecodeFunc(t, true)
 	}
@@ -201,8 +205,8 @@ func constructCodec(t reflect.Type, seen map[reflect.Type]*structType) (c codec)
 	return
 }
 
-func constructStringCodec(t reflect.Type, seen map[reflect.Type]*structType) codec {
-	c := constructCodec(t, seen)
+func constructStringCodec(t reflect.Type, seen map[reflect.Type]*structType, canAddr bool) codec {
+	c := constructCodec(t, seen, canAddr)
 	return codec{
 		encode: constructStringEncodeFunc(c.encode),
 		decode: constructStringDecodeFunc(c.decode),
@@ -221,9 +225,15 @@ func constructStringDecodeFunc(decode decodeFunc) decodeFunc {
 	}
 }
 
-func constructArrayCodec(t reflect.Type, seen map[reflect.Type]*structType) codec {
+func constructStringToIntDecodeFunc(t reflect.Type, decode decodeFunc) decodeFunc {
+	return func(d decoder, b []byte, p unsafe.Pointer) ([]byte, error) {
+		return d.decodeFromStringToInt(b, p, t, decode)
+	}
+}
+
+func constructArrayCodec(t reflect.Type, seen map[reflect.Type]*structType, canAddr bool) codec {
 	e := t.Elem()
-	c := constructCodec(e, seen)
+	c := constructCodec(e, seen, canAddr)
 	s := alignedSize(e)
 	return codec{
 		encode: constructArrayEncodeFunc(s, t, c.encode),
@@ -250,12 +260,12 @@ func constructSliceCodec(t reflect.Type, seen map[reflect.Type]*structType) code
 	s := alignedSize(e)
 
 	if e.Kind() == reflect.Uint8 {
-		p := reflect.PtrTo(e)
-		c := codec{}
-
 		// Go 1.7+ behavior: slices of byte types (and aliases) may override the
 		// default encoding and decoding behaviors by implementing marshaler and
 		// unmarshaler interfaces.
+		p := reflect.PtrTo(e)
+		c := codec{}
+
 		switch {
 		case e.Implements(jsonMarshalerType):
 			c.encode = constructJSONMarshalerEncodeFunc(e, false)
@@ -293,7 +303,7 @@ func constructSliceCodec(t reflect.Type, seen map[reflect.Type]*structType) code
 		return c
 	}
 
-	c := constructCodec(e, seen)
+	c := constructCodec(e, seen, true)
 	return codec{
 		encode: constructSliceEncodeFunc(s, t, c.encode),
 		decode: constructSliceDecodeFunc(s, t, c.decode),
@@ -333,7 +343,7 @@ func constructMapCodec(t reflect.Type, seen map[reflect.Type]*structType) codec 
 	}
 
 	kc := codec{}
-	vc := constructCodec(v, seen)
+	vc := constructCodec(v, seen, false)
 
 	if k.Implements(textMarshalerType) || reflect.PtrTo(k).Implements(textUnmarshalerType) {
 		kc.encode = constructTextMarshalerEncodeFunc(k, false)
@@ -363,10 +373,10 @@ func constructMapCodec(t reflect.Type, seen map[reflect.Type]*structType) codec 
 			reflect.Int16,
 			reflect.Int32,
 			reflect.Int64:
-			kc = constructStringCodec(k, seen)
+			kc = constructStringCodec(k, seen, false)
 
 			sortKeys = func(keys []reflect.Value) {
-				sort.Slice(keys, func(i, j int) bool { return keys[i].Int() < keys[j].Int() })
+				sort.Slice(keys, func(i, j int) bool { return intStringsAreSorted(keys[i].Int(), keys[j].Int()) })
 			}
 
 		case reflect.Uint,
@@ -375,19 +385,18 @@ func constructMapCodec(t reflect.Type, seen map[reflect.Type]*structType) codec 
 			reflect.Uint16,
 			reflect.Uint32,
 			reflect.Uint64:
-			kc = constructStringCodec(k, seen)
+			kc = constructStringCodec(k, seen, false)
 
 			sortKeys = func(keys []reflect.Value) {
-				sort.Slice(keys, func(i, j int) bool { return keys[i].Uint() < keys[j].Uint() })
+				sort.Slice(keys, func(i, j int) bool { return uintStringsAreSorted(keys[i].Uint(), keys[j].Uint()) })
 			}
 
 		default:
-			return constructUnmarshalTypeErrorCodec(t)
+			return constructUnsupportedTypeCodec(t)
 		}
 	}
 
-	switch v.Kind() {
-	case reflect.Ptr, reflect.Map:
+	if inlined(v) {
 		vc.encode = constructInlineValueEncodeFunc(vc.encode)
 	}
 
@@ -413,15 +422,15 @@ func constructMapDecodeFunc(t reflect.Type, decodeKey, decodeValue decodeFunc) d
 	}
 }
 
-func constructStructCodec(t reflect.Type, seen map[reflect.Type]*structType) codec {
-	st := constructStructType(t, seen)
+func constructStructCodec(t reflect.Type, seen map[reflect.Type]*structType, canAddr bool) codec {
+	st := constructStructType(t, seen, canAddr)
 	return codec{
 		encode: constructStructEncodeFunc(st),
 		decode: constructStructDecodeFunc(st),
 	}
 }
 
-func constructStructType(t reflect.Type, seen map[reflect.Type]*structType) *structType {
+func constructStructType(t reflect.Type, seen map[reflect.Type]*structType, canAddr bool) *structType {
 	// Used for preventing infinite recursion on types that have pointers to
 	// themselves.
 	st := seen[t]
@@ -435,7 +444,7 @@ func constructStructType(t reflect.Type, seen map[reflect.Type]*structType) *str
 		}
 
 		seen[t] = st
-		st.fields = appendStructFields(st.fields, t, 0, seen)
+		st.fields = appendStructFields(st.fields, t, 0, seen, canAddr)
 
 		for i := range st.fields {
 			f := &st.fields[i]
@@ -483,7 +492,7 @@ func constructEmbeddedStructPointerDecodeFunc(t reflect.Type, unexported bool, o
 	}
 }
 
-func appendStructFields(fields []structField, t reflect.Type, offset uintptr, seen map[reflect.Type]*structType) []structField {
+func appendStructFields(fields []structField, t reflect.Type, offset uintptr, seen map[reflect.Type]*structType, canAddr bool) []structField {
 	type embeddedField struct {
 		index      int
 		offset     uintptr
@@ -548,7 +557,7 @@ func appendStructFields(fields []structField, t reflect.Type, offset uintptr, se
 				// up by offset from the address of the wrapping object, so we
 				// simply add the embedded struct fields to the list of fields
 				// of the current struct type.
-				subtype := constructStructType(typ, seen)
+				subtype := constructStructType(typ, seen, canAddr)
 
 				for j := range subtype.fields {
 					embedded = append(embedded, embeddedField{
@@ -569,7 +578,7 @@ func appendStructFields(fields []structField, t reflect.Type, offset uintptr, se
 			}
 		}
 
-		codec := constructCodec(f.Type, seen)
+		codec := constructCodec(f.Type, seen, canAddr)
 
 		if stringify {
 			// https://golang.org/pkg/encoding/json/#Marshal
@@ -586,8 +595,7 @@ func appendStructFields(fields []structField, t reflect.Type, offset uintptr, se
 			}
 
 			switch typ.Kind() {
-			case reflect.Bool,
-				reflect.Int,
+			case reflect.Int,
 				reflect.Int8,
 				reflect.Int16,
 				reflect.Int32,
@@ -597,7 +605,10 @@ func appendStructFields(fields []structField, t reflect.Type, offset uintptr, se
 				reflect.Uint8,
 				reflect.Uint16,
 				reflect.Uint32,
-				reflect.Uint64,
+				reflect.Uint64:
+				codec.encode = constructStringEncodeFunc(codec.encode)
+				codec.decode = constructStringToIntDecodeFunc(typ, codec.decode)
+			case reflect.Bool,
 				reflect.Float32,
 				reflect.Float64,
 				reflect.String:
@@ -607,13 +618,13 @@ func appendStructFields(fields []structField, t reflect.Type, offset uintptr, se
 		}
 
 		fields = append(fields, structField{
-			name:      name,
-			index:     i << 32,
-			offset:    offset + f.Offset,
 			codec:     codec,
+			offset:    offset + f.Offset,
 			empty:     emptyFuncOf(f.Type),
 			tag:       tag,
 			omitempty: omitempty,
+			name:      name,
+			index:     i << 32,
 			typ:       f.Type,
 			zero:      reflect.Zero(f.Type),
 		})
@@ -663,13 +674,25 @@ func appendStructFields(fields []structField, t reflect.Type, offset uintptr, se
 		fields = append(fields, subfield)
 	}
 
+	for i := range fields {
+		fields[i].json = encodeString(fields[i].name, 0)
+		fields[i].html = encodeString(fields[i].name, EscapeHTML)
+	}
+
 	sort.Slice(fields, func(i, j int) bool { return fields[i].index < fields[j].index })
 	return fields
 }
 
+func encodeString(s string, flags AppendFlags) string {
+	b := make([]byte, 0, len(s)+2)
+	e := encoder{flags: flags}
+	b, _ = e.encodeString(b, unsafe.Pointer(&s))
+	return *(*string)(unsafe.Pointer(&b))
+}
+
 func constructPointerCodec(t reflect.Type, seen map[reflect.Type]*structType) codec {
 	e := t.Elem()
-	c := constructCodec(e, seen)
+	c := constructCodec(e, seen, true)
 	return codec{
 		encode: constructPointerEncodeFunc(e, c.encode),
 		decode: constructPointerDecodeFunc(e, c.decode),
@@ -688,20 +711,39 @@ func constructPointerDecodeFunc(t reflect.Type, decode decodeFunc) decodeFunc {
 	}
 }
 
-func constructUnmarshalTypeErrorCodec(t reflect.Type) codec {
+func constructInterfaceCodec(t reflect.Type) codec {
 	return codec{
-		encode: constructUnmarshalTypeErrorEncodeFunc(t),
-		decode: constructUnmarshalTypeErrorDecodeFunc(t),
+		encode: constructMaybeEmptyInterfaceEncoderFunc(t),
+		decode: constructMaybeEmptyInterfaceDecoderFunc(t),
 	}
 }
 
-func constructUnmarshalTypeErrorEncodeFunc(t reflect.Type) encodeFunc {
+func constructMaybeEmptyInterfaceEncoderFunc(t reflect.Type) encodeFunc {
 	return func(e encoder, b []byte, p unsafe.Pointer) ([]byte, error) {
-		return e.encodeUnsupportedType(b, p, t)
+		return e.encodeMaybeEmptyInterface(b, p, t)
 	}
 }
 
-func constructUnmarshalTypeErrorDecodeFunc(t reflect.Type) decodeFunc {
+func constructMaybeEmptyInterfaceDecoderFunc(t reflect.Type) decodeFunc {
+	return func(d decoder, b []byte, p unsafe.Pointer) ([]byte, error) {
+		return d.decodeMaybeEmptyInterface(b, p, t)
+	}
+}
+
+func constructUnsupportedTypeCodec(t reflect.Type) codec {
+	return codec{
+		encode: constructUnsupportedTypeEncodeFunc(t),
+		decode: constructUnsupportedTypeDecodeFunc(t),
+	}
+}
+
+func constructUnsupportedTypeEncodeFunc(t reflect.Type) encodeFunc {
+	return func(e encoder, b []byte, p unsafe.Pointer) ([]byte, error) {
+		return e.encodeUnsupportedTypeError(b, p, t)
+	}
+}
+
+func constructUnsupportedTypeDecodeFunc(t reflect.Type) decodeFunc {
 	return func(d decoder, b []byte, p unsafe.Pointer) ([]byte, error) {
 		return d.decodeUnmarshalTypeError(b, p, t)
 	}
@@ -872,15 +914,17 @@ type structType struct {
 }
 
 type structField struct {
-	name      string
-	index     int
-	offset    uintptr
 	codec     codec
+	offset    uintptr
 	empty     emptyFunc
 	tag       bool
 	omitempty bool
+	json      string
+	html      string
+	name      string
 	typ       reflect.Type
 	zero      reflect.Value
+	index     int
 }
 
 func unmarshalTypeError(b []byte, t reflect.Type) error {
@@ -891,19 +935,53 @@ func unmarshalOverflow(b []byte, t reflect.Type) error {
 	return &UnmarshalTypeError{Value: "number " + prefix(b) + " overflows", Type: t}
 }
 
-func syntaxError(b []byte, msg string, args ...interface{}) error {
-	e := new(SyntaxError)
-	t := reflect.TypeOf(e).Elem()
-	p := unsafe.Pointer(e)
+func unexpectedEOF(b []byte) error {
+	return syntaxError(b, "unexpected end of JSON input")
+}
 
+var syntaxErrorMsgOffset = ^uintptr(0)
+
+func init() {
+	t := reflect.TypeOf(SyntaxError{})
 	for i, n := 0, t.NumField(); i < n; i++ {
 		if f := t.Field(i); f.Type.Kind() == reflect.String {
-			// Hack to set the unexported `msg` field.
-			*(*string)(unsafe.Pointer(uintptr(p) + f.Offset)) = "json: " + fmt.Sprintf(msg, args...) + ": " + prefix(b)
+			syntaxErrorMsgOffset = f.Offset
 		}
 	}
+}
 
+func syntaxError(b []byte, msg string, args ...interface{}) error {
+	e := new(SyntaxError)
+	i := syntaxErrorMsgOffset
+	if i != ^uintptr(0) {
+		s := "json: " + fmt.Sprintf(msg, args...) + ": " + prefix(b)
+		p := unsafe.Pointer(e)
+		// Hack to set the unexported `msg` field.
+		*(*string)(unsafe.Pointer(uintptr(p) + i)) = s
+	}
 	return e
+}
+
+func inputError(b []byte, t reflect.Type) ([]byte, error) {
+	if len(b) == 0 {
+		return nil, unexpectedEOF(b)
+	}
+	_, r, err := parseValue(b)
+	if err != nil {
+		return r, err
+	}
+	return skipSpaces(r), unmarshalTypeError(b, t)
+}
+
+func objectKeyError(b []byte, err error) ([]byte, error) {
+	if len(b) == 0 {
+		return nil, unexpectedEOF(b)
+	}
+	switch err.(type) {
+	case *UnmarshalTypeError:
+		err = syntaxError(b, "invalid character '%c' looking for beginning of object key", b[0])
+	}
+	return b, err
 }
 
 func prefix(b []byte) string {
@@ -911,6 +989,16 @@ func prefix(b []byte) string {
 		return string(b)
 	}
 	return string(b[:32]) + "..."
+}
+
+func intStringsAreSorted(i0, i1 int64) bool {
+	var b0, b1 [32]byte
+	return string(strconv.AppendInt(b0[:0], i0, 10)) < string(strconv.AppendInt(b1[:0], i1, 10))
+}
+
+func uintStringsAreSorted(u0, u1 uint64) bool {
+	var b0, b1 [32]byte
+	return string(strconv.AppendUint(b0[:0], u0, 10)) < string(strconv.AppendUint(b1[:0], u1, 10))
 }
 
 //go:nosplit
@@ -932,11 +1020,12 @@ var (
 	int32Type = reflect.TypeOf(int32(0))
 	int64Type = reflect.TypeOf(int64(0))
 
-	uintType   = reflect.TypeOf(uint(0))
-	uint8Type  = reflect.TypeOf(uint8(0))
-	uint16Type = reflect.TypeOf(uint16(0))
-	uint32Type = reflect.TypeOf(uint32(0))
-	uint64Type = reflect.TypeOf(uint64(0))
+	uintType    = reflect.TypeOf(uint(0))
+	uint8Type   = reflect.TypeOf(uint8(0))
+	uint16Type  = reflect.TypeOf(uint16(0))
+	uint32Type  = reflect.TypeOf(uint32(0))
+	uint64Type  = reflect.TypeOf(uint64(0))
+	uintptrType = reflect.TypeOf(uintptr(0))
 
 	float32Type = reflect.TypeOf(float32(0))
 	float64Type = reflect.TypeOf(float64(0))

--- a/vendor/github.com/segmentio/encoding/json/decode.go
+++ b/vendor/github.com/segmentio/encoding/json/decode.go
@@ -14,38 +14,38 @@ import (
 )
 
 func (d decoder) decodeNull(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		return b[4:], nil
 	}
-	return b, unmarshalTypeError(b, nullType)
+	return inputError(b, nullType)
 }
 
 func (d decoder) decodeBool(b []byte, p unsafe.Pointer) ([]byte, error) {
 	switch {
-	case hasPrefix(b, "true"):
+	case hasTruePrefix(b):
 		*(*bool)(p) = true
 		return b[4:], nil
 
-	case hasPrefix(b, "false"):
+	case hasFalsePrefix(b):
 		*(*bool)(p) = false
 		return b[5:], nil
 
-	case hasPrefix(b, "null"):
+	case hasNullPrefix(b):
 		return b[4:], nil
 
 	default:
-		return b, unmarshalTypeError(b, boolType)
+		return inputError(b, boolType)
 	}
 }
 
 func (d decoder) decodeInt(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		return b[4:], nil
 	}
 
-	v, r, err := parseInt(b)
+	v, r, err := parseInt(b, intType)
 	if err != nil {
-		return r, unmarshalTypeError(b, intType)
+		return r, err
 	}
 
 	*(*int)(p) = int(v)
@@ -53,13 +53,13 @@ func (d decoder) decodeInt(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (d decoder) decodeInt8(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		return b[4:], nil
 	}
 
-	v, r, err := parseInt(b)
+	v, r, err := parseInt(b, int8Type)
 	if err != nil {
-		return r, unmarshalTypeError(b, int8Type)
+		return r, err
 	}
 
 	if v < math.MinInt8 || v > math.MaxInt8 {
@@ -71,13 +71,13 @@ func (d decoder) decodeInt8(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (d decoder) decodeInt16(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		return b[4:], nil
 	}
 
-	v, r, err := parseInt(b)
+	v, r, err := parseInt(b, int16Type)
 	if err != nil {
-		return r, unmarshalTypeError(b, int16Type)
+		return r, err
 	}
 
 	if v < math.MinInt16 || v > math.MaxInt16 {
@@ -89,13 +89,13 @@ func (d decoder) decodeInt16(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (d decoder) decodeInt32(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		return b[4:], nil
 	}
 
-	v, r, err := parseInt(b)
+	v, r, err := parseInt(b, int32Type)
 	if err != nil {
-		return r, unmarshalTypeError(b, int32Type)
+		return r, err
 	}
 
 	if v < math.MinInt32 || v > math.MaxInt32 {
@@ -107,13 +107,13 @@ func (d decoder) decodeInt32(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (d decoder) decodeInt64(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		return b[4:], nil
 	}
 
-	v, r, err := parseInt(b)
+	v, r, err := parseInt(b, int64Type)
 	if err != nil {
-		return r, unmarshalTypeError(b, int64Type)
+		return r, err
 	}
 
 	*(*int64)(p) = v
@@ -121,13 +121,13 @@ func (d decoder) decodeInt64(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (d decoder) decodeUint(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		return b[4:], nil
 	}
 
-	v, r, err := parseUint(b)
+	v, r, err := parseUint(b, uintType)
 	if err != nil {
-		return r, unmarshalTypeError(b, uintType)
+		return r, err
 	}
 
 	*(*uint)(p) = uint(v)
@@ -135,13 +135,13 @@ func (d decoder) decodeUint(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (d decoder) decodeUintptr(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		return b[4:], nil
 	}
 
-	v, r, err := parseUint(b)
+	v, r, err := parseUint(b, uintptrType)
 	if err != nil {
-		return r, unmarshalTypeError(b, uintType)
+		return r, err
 	}
 
 	*(*uintptr)(p) = uintptr(v)
@@ -149,13 +149,13 @@ func (d decoder) decodeUintptr(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (d decoder) decodeUint8(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		return b[4:], nil
 	}
 
-	v, r, err := parseUint(b)
+	v, r, err := parseUint(b, uint8Type)
 	if err != nil {
-		return r, unmarshalTypeError(b, uint8Type)
+		return r, err
 	}
 
 	if v > math.MaxUint8 {
@@ -167,13 +167,13 @@ func (d decoder) decodeUint8(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (d decoder) decodeUint16(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		return b[4:], nil
 	}
 
-	v, r, err := parseUint(b)
+	v, r, err := parseUint(b, uint16Type)
 	if err != nil {
-		return r, unmarshalTypeError(b, uint16Type)
+		return r, err
 	}
 
 	if v > math.MaxUint16 {
@@ -185,13 +185,13 @@ func (d decoder) decodeUint16(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (d decoder) decodeUint32(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		return b[4:], nil
 	}
 
-	v, r, err := parseUint(b)
+	v, r, err := parseUint(b, uint32Type)
 	if err != nil {
-		return r, unmarshalTypeError(b, uint32Type)
+		return r, err
 	}
 
 	if v > math.MaxUint32 {
@@ -203,13 +203,13 @@ func (d decoder) decodeUint32(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (d decoder) decodeUint64(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		return b[4:], nil
 	}
 
-	v, r, err := parseUint(b)
+	v, r, err := parseUint(b, uint64Type)
 	if err != nil {
-		return r, unmarshalTypeError(b, uint64Type)
+		return r, err
 	}
 
 	*(*uint64)(p) = v
@@ -217,18 +217,18 @@ func (d decoder) decodeUint64(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (d decoder) decodeFloat32(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		return b[4:], nil
 	}
 
 	v, r, err := parseNumber(b)
 	if err != nil {
-		return r, unmarshalTypeError(b, float32Type)
+		return inputError(b, float32Type)
 	}
 
 	f, err := strconv.ParseFloat(*(*string)(unsafe.Pointer(&v)), 32)
 	if err != nil {
-		return r, unmarshalTypeError(b, float32Type)
+		return inputError(b, float32Type)
 	}
 
 	*(*float32)(p) = float32(f)
@@ -236,18 +236,18 @@ func (d decoder) decodeFloat32(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (d decoder) decodeFloat64(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		return b[4:], nil
 	}
 
 	v, r, err := parseNumber(b)
 	if err != nil {
-		return r, unmarshalTypeError(b, float64Type)
+		return inputError(b, float64Type)
 	}
 
 	f, err := strconv.ParseFloat(*(*string)(unsafe.Pointer(&v)), 64)
 	if err != nil {
-		return r, unmarshalTypeError(b, float64Type)
+		return inputError(b, float64Type)
 	}
 
 	*(*float64)(p) = f
@@ -255,13 +255,13 @@ func (d decoder) decodeFloat64(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (d decoder) decodeNumber(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		return b[4:], nil
 	}
 
 	v, r, err := parseNumber(b)
 	if err != nil {
-		return r, unmarshalTypeError(b, numberType)
+		return inputError(b, numberType)
 	}
 
 	if (d.flags & DontCopyNumber) != 0 {
@@ -274,13 +274,16 @@ func (d decoder) decodeNumber(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (d decoder) decodeString(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		return b[4:], nil
 	}
 
 	s, r, new, err := parseStringUnquote(b, nil)
 	if err != nil {
-		return b, unmarshalTypeError(r, stringType)
+		if len(b) == 0 || b[0] != '"' {
+			return inputError(b, stringType)
+		}
+		return r, err
 	}
 
 	if new || (d.flags&DontCopyString) != 0 {
@@ -293,13 +296,13 @@ func (d decoder) decodeString(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (d decoder) decodeFromString(b []byte, p unsafe.Pointer, decode decodeFunc) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		return decode(d, b, p)
 	}
 
 	v, b, _, err := parseStringUnquote(b, nil)
 	if err != nil {
-		return b, unmarshalTypeError(v, stringType)
+		return inputError(v, stringType)
 	}
 
 	if v, err = decode(d, v, p); err != nil {
@@ -313,31 +316,119 @@ func (d decoder) decodeFromString(b []byte, p unsafe.Pointer, decode decodeFunc)
 	return b, nil
 }
 
-func (d decoder) decodeBytes(b []byte, p unsafe.Pointer) ([]byte, error) {
+func (d decoder) decodeFromStringToInt(b []byte, p unsafe.Pointer, t reflect.Type, decode decodeFunc) ([]byte, error) {
 	if hasPrefix(b, "null") {
+		return decode(d, b, p)
+	}
+
+	if len(b) > 0 && b[0] != '"' {
+		v, r, err := parseNumber(b)
+		if err == nil {
+			// The encoding/json package will return a *json.UnmarshalTypeError if
+			// the input was a floating point number representation, even tho a
+			// string is expected here.
+			isFloat := true
+			switch {
+			case bytes.IndexByte(v, '.') >= 0:
+			case bytes.IndexByte(v, 'e') >= 0:
+			case bytes.IndexByte(v, 'E') >= 0:
+			default:
+				isFloat = false
+			}
+			if isFloat {
+				_, err := strconv.ParseFloat(*(*string)(unsafe.Pointer(&v)), 64)
+				if err != nil {
+					return r, unmarshalTypeError(v, t)
+				}
+			}
+		}
+		return r, fmt.Errorf("json: invalid use of ,string struct tag, trying to unmarshal unquoted value into int")
+	}
+
+	if len(b) > 1 && b[0] == '"' && b[1] == '"' {
+		return b, fmt.Errorf("json: invalid use of ,string struct tag, trying to unmarshal \"\" into int")
+	}
+
+	v, b, _, err := parseStringUnquote(b, nil)
+	if err != nil {
+		return inputError(v, t)
+	}
+
+	if hasLeadingZeroes(v) {
+		// In this context the encoding/json package accepts leading zeroes because
+		// it is not constrained by the JSON syntax, remove them so the parsing
+		// functions don't return syntax errors.
+		u := make([]byte, 0, len(v))
+		i := 0
+
+		if i < len(v) && v[i] == '-' || v[i] == '+' {
+			u = append(u, v[i])
+			i++
+		}
+
+		for (i+1) < len(v) && v[i] == '0' && '0' <= v[i+1] && v[i+1] <= '9' {
+			i++
+		}
+
+		v = append(u, v[i:]...)
+	}
+
+	if r, err := decode(d, v, p); err != nil {
+		if _, isSyntaxError := err.(*SyntaxError); isSyntaxError {
+			if hasPrefix(v, "-") {
+				// The standard library interprets sequences of '-' characters
+				// as numbers but still returns type errors in this case...
+				return b, unmarshalTypeError(v, t)
+			}
+			return b, fmt.Errorf("json: invalid use of ,string struct tag, trying to unmarshal %q into int", prefix(v))
+		}
+		// When the input value was a valid number representation we retain the
+		// error returned by the decoder.
+		if _, _, err := parseNumber(v); err != nil {
+			// When the input value valid JSON we mirror the behavior of the
+			// encoding/json package and return a generic error.
+			if _, _, err := parseValue(v); err == nil {
+				return b, fmt.Errorf("json: invalid use of ,string struct tag, trying to unmarshal %q into int", prefix(v))
+			}
+		}
+		return b, err
+	} else if len(r) != 0 {
+		return r, unmarshalTypeError(v, t)
+	}
+
+	return b, nil
+}
+
+func (d decoder) decodeBytes(b []byte, p unsafe.Pointer) ([]byte, error) {
+	if hasNullPrefix(b) {
+		*(*[]byte)(p) = nil
 		return b[4:], nil
 	}
 
-	if len(b) < 2 || b[0] != '"' {
+	if len(b) < 2 {
+		return inputError(b, bytesType)
+	}
+
+	if b[0] != '"' {
 		// Go 1.7- behavior: bytes slices may be decoded from array of integers.
-		if len(b) >= 1 && b[0] == '[' {
+		if len(b) > 0 && b[0] == '[' {
 			return d.decodeSlice(b, p, 1, bytesType, decoder.decodeUint8)
 		}
-		return b, unmarshalTypeError(b, bytesType)
+		return inputError(b, bytesType)
 	}
 
 	// The input string contains escaped sequences, we need to parse it before
 	// decoding it to match the encoding/json package behvaior.
 	src, r, _, err := parseStringUnquote(b, nil)
 	if err != nil {
-		return b, unmarshalTypeError(b, bytesType)
+		return inputError(b, bytesType)
 	}
 
 	dst := make([]byte, base64.StdEncoding.DecodedLen(len(src)))
 
 	n, err := base64.StdEncoding.Decode(dst, src)
 	if err != nil {
-		return b, unmarshalTypeError(b, bytesType)
+		return r, err
 	}
 
 	*(*[]byte)(p) = dst[:n]
@@ -345,7 +436,7 @@ func (d decoder) decodeBytes(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (d decoder) decodeDuration(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		return b[4:], nil
 	}
 
@@ -354,9 +445,9 @@ func (d decoder) decodeDuration(b []byte, p unsafe.Pointer) ([]byte, error) {
 	// flexible on how durations are formatted, but for the time being, it's
 	// been punted to go2 at the earliest: https://github.com/golang/go/issues/4712
 	if len(b) > 0 && b[0] != '"' {
-		v, r, err := parseInt(b)
+		v, r, err := parseInt(b, durationType)
 		if err != nil {
-			return r, unmarshalTypeError(b, int32Type)
+			return inputError(b, int32Type)
 		}
 
 		if v < math.MinInt64 || v > math.MaxInt64 {
@@ -368,19 +459,19 @@ func (d decoder) decodeDuration(b []byte, p unsafe.Pointer) ([]byte, error) {
 	}
 
 	if len(b) < 2 || b[0] != '"' {
-		return b, unmarshalTypeError(b, durationType)
+		return inputError(b, durationType)
 	}
 
 	i := bytes.IndexByte(b[1:], '"') + 1
 	if i <= 0 {
-		return b, unmarshalTypeError(b, durationType)
+		return inputError(b, durationType)
 	}
 
 	s := b[1:i] // trim quotes
 
 	v, err := time.ParseDuration(*(*string)(unsafe.Pointer(&s)))
 	if err != nil {
-		return b, unmarshalTypeError(b, durationType)
+		return inputError(b, durationType)
 	}
 
 	*(*time.Duration)(p) = v
@@ -388,24 +479,24 @@ func (d decoder) decodeDuration(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (d decoder) decodeTime(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		return b[4:], nil
 	}
 
 	if len(b) < 2 || b[0] != '"' {
-		return b, unmarshalTypeError(b, durationType)
+		return inputError(b, timeType)
 	}
 
 	i := bytes.IndexByte(b[1:], '"') + 1
 	if i <= 0 {
-		return b, unmarshalTypeError(b, durationType)
+		return inputError(b, timeType)
 	}
 
 	s := b[1:i] // trim quotes
 
 	v, err := time.Parse(time.RFC3339Nano, *(*string)(unsafe.Pointer(&s)))
 	if err != nil {
-		return b, unmarshalTypeError(b, durationType)
+		return inputError(b, timeType)
 	}
 
 	*(*time.Time)(p) = v
@@ -413,12 +504,12 @@ func (d decoder) decodeTime(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (d decoder) decodeArray(b []byte, p unsafe.Pointer, n int, size uintptr, t reflect.Type, decode decodeFunc) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		return b[4:], nil
 	}
 
 	if len(b) < 2 || b[0] != '[' {
-		return b, unmarshalTypeError(b, t)
+		return inputError(b, t)
 	}
 	b = b[1:]
 
@@ -473,21 +564,32 @@ func (d decoder) decodeArray(b []byte, p unsafe.Pointer, n int, size uintptr, t 
 	}
 }
 
+var (
+	// This is a placeholder used to consturct non-nil empty slices.
+	empty struct{}
+)
+
 func (d decoder) decodeSlice(b []byte, p unsafe.Pointer, size uintptr, t reflect.Type, decode decodeFunc) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		*(*slice)(p) = slice{}
 		return b[4:], nil
 	}
 
-	if len(b) < 2 || b[0] != '[' {
+	if len(b) < 2 {
+		return inputError(b, t)
+	}
+
+	if b[0] != '[' {
 		// Go 1.7- behavior: fallback to decoding as a []byte if the element
 		// type is byte; allow conversions from JSON strings even tho the
 		// underlying type implemented unmarshaler interfaces.
 		if t.Elem().Kind() == reflect.Uint8 {
 			return d.decodeBytes(b, p)
 		}
-		return b, unmarshalTypeError(b, t)
+		return inputError(b, t)
 	}
+
+	input := b
 	b = b[1:]
 
 	s := (*slice)(p)
@@ -523,14 +625,16 @@ func (d decoder) decodeSlice(b []byte, p unsafe.Pointer, size uintptr, t reflect
 				c *= 2
 			}
 
-			v := reflect.MakeSlice(t, s.len, c)
-			reflect.Copy(v, reflect.NewAt(t, p).Elem())
-
-			*s = *(*slice)((*iface)(unsafe.Pointer(&v)).ptr)
+			*s = extendSlice(t, s, c)
 		}
 
 		b, err = decode(d, b, unsafe.Pointer(uintptr(s.data)+(uintptr(s.len)*size)))
 		if err != nil {
+			if _, r, err := parseValue(input); err != nil {
+				return r, err
+			} else {
+				b = r
+			}
 			if e, ok := err.(*UnmarshalTypeError); ok {
 				e.Struct = t.String() + e.Struct
 				e.Field = strconv.Itoa(s.len) + "." + e.Field
@@ -543,16 +647,14 @@ func (d decoder) decodeSlice(b []byte, p unsafe.Pointer, size uintptr, t reflect
 }
 
 func (d decoder) decodeMap(b []byte, p unsafe.Pointer, t, kt, vt reflect.Type, kz, vz reflect.Value, decodeKey, decodeValue decodeFunc) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		*(*unsafe.Pointer)(p) = nil
 		return b[4:], nil
 	}
 
 	if len(b) < 2 || b[0] != '{' {
-		return b, unmarshalTypeError(b, t)
+		return inputError(b, t)
 	}
-	b = b[1:]
-
 	i := 0
 	m := reflect.NewAt(t, p).Elem()
 
@@ -561,12 +663,14 @@ func (d decoder) decodeMap(b []byte, p unsafe.Pointer, t, kt, vt reflect.Type, k
 
 	kptr := (*iface)(unsafe.Pointer(&k)).ptr
 	vptr := (*iface)(unsafe.Pointer(&v)).ptr
+	input := b
 
 	if m.IsNil() {
 		m = reflect.MakeMap(t)
 	}
 
 	var err error
+	b = b[1:]
 	for {
 		k.Set(kz)
 		v.Set(vz)
@@ -579,7 +683,7 @@ func (d decoder) decodeMap(b []byte, p unsafe.Pointer, t, kt, vt reflect.Type, k
 
 		if i != 0 {
 			if len(b) == 0 {
-				return b, syntaxError(b, "unexpected EOF after object field value")
+				return b, syntaxError(b, "unexpected end of JONS input after object field value")
 			}
 			if b[0] != ',' {
 				return b, syntaxError(b, "expected ',' after object field value but found '%c'", b[0])
@@ -587,13 +691,17 @@ func (d decoder) decodeMap(b []byte, p unsafe.Pointer, t, kt, vt reflect.Type, k
 			b = skipSpaces(b[1:])
 		}
 
+		if hasPrefix(b, "null") {
+			return b, syntaxError(b, "cannot decode object key string from 'null' value")
+		}
+
 		if b, err = decodeKey(d, b, kptr); err != nil {
-			return b, err
+			return objectKeyError(b, err)
 		}
 		b = skipSpaces(b)
 
 		if len(b) == 0 {
-			return b, syntaxError(b, "unexpected EOF after object field key")
+			return b, syntaxError(b, "unexpected end of JSON input after object field key")
 		}
 		if b[0] != ':' {
 			return b, syntaxError(b, "expected ':' after object field key but found '%c'", b[0])
@@ -601,6 +709,11 @@ func (d decoder) decodeMap(b []byte, p unsafe.Pointer, t, kt, vt reflect.Type, k
 		b = skipSpaces(b[1:])
 
 		if b, err = decodeValue(d, b, vptr); err != nil {
+			if _, r, err := parseValue(input); err != nil {
+				return r, err
+			} else {
+				b = r
+			}
 			if e, ok := err.(*UnmarshalTypeError); ok {
 				e.Struct = "map[" + kt.String() + "]" + vt.String() + "{" + e.Struct + "}"
 				e.Field = fmt.Sprint(k.Interface()) + "." + e.Field
@@ -614,15 +727,14 @@ func (d decoder) decodeMap(b []byte, p unsafe.Pointer, t, kt, vt reflect.Type, k
 }
 
 func (d decoder) decodeMapStringInterface(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		*(*unsafe.Pointer)(p) = nil
 		return b[4:], nil
 	}
 
 	if len(b) < 2 || b[0] != '{' {
-		return b, unmarshalTypeError(b, mapStringInterfaceType)
+		return inputError(b, mapStringInterfaceType)
 	}
-	b = b[1:]
 
 	i := 0
 	m := *(*map[string]interface{})(p)
@@ -634,7 +746,9 @@ func (d decoder) decodeMapStringInterface(b []byte, p unsafe.Pointer) ([]byte, e
 	var err error
 	var key string
 	var val interface{}
+	var input = b
 
+	b = b[1:]
 	for {
 		key = ""
 		val = nil
@@ -648,7 +762,7 @@ func (d decoder) decodeMapStringInterface(b []byte, p unsafe.Pointer) ([]byte, e
 
 		if i != 0 {
 			if len(b) == 0 {
-				return b, syntaxError(b, "unexpected EOF after object field value")
+				return b, syntaxError(b, "unexpected end of JSON input after object field value")
 			}
 			if b[0] != ',' {
 				return b, syntaxError(b, "expected ',' after object field value but found '%c'", b[0])
@@ -656,14 +770,18 @@ func (d decoder) decodeMapStringInterface(b []byte, p unsafe.Pointer) ([]byte, e
 			b = skipSpaces(b[1:])
 		}
 
+		if hasPrefix(b, "null") {
+			return b, syntaxError(b, "cannot decode object key string from 'null' value")
+		}
+
 		b, err = d.decodeString(b, unsafe.Pointer(&key))
 		if err != nil {
-			return b, err
+			return objectKeyError(b, err)
 		}
 		b = skipSpaces(b)
 
 		if len(b) == 0 {
-			return b, syntaxError(b, "unexpected EOF after object field key")
+			return b, syntaxError(b, "unexpected end of JSON input after object field key")
 		}
 		if b[0] != ':' {
 			return b, syntaxError(b, "expected ':' after object field key but found '%c'", b[0])
@@ -672,6 +790,11 @@ func (d decoder) decodeMapStringInterface(b []byte, p unsafe.Pointer) ([]byte, e
 
 		b, err = d.decodeInterface(b, unsafe.Pointer(&val))
 		if err != nil {
+			if _, r, err := parseValue(input); err != nil {
+				return r, err
+			} else {
+				b = r
+			}
 			if e, ok := err.(*UnmarshalTypeError); ok {
 				e.Struct = mapStringInterfaceType.String() + e.Struct
 				e.Field = key + "." + e.Field
@@ -685,15 +808,14 @@ func (d decoder) decodeMapStringInterface(b []byte, p unsafe.Pointer) ([]byte, e
 }
 
 func (d decoder) decodeMapStringRawMessage(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		*(*unsafe.Pointer)(p) = nil
 		return b[4:], nil
 	}
 
 	if len(b) < 2 || b[0] != '{' {
-		return b, unmarshalTypeError(b, mapStringInterfaceType)
+		return inputError(b, mapStringRawMessageType)
 	}
-	b = b[1:]
 
 	i := 0
 	m := *(*map[string]RawMessage)(p)
@@ -705,7 +827,9 @@ func (d decoder) decodeMapStringRawMessage(b []byte, p unsafe.Pointer) ([]byte, 
 	var err error
 	var key string
 	var val RawMessage
+	var input = b
 
+	b = b[1:]
 	for {
 		key = ""
 		val = nil
@@ -719,7 +843,7 @@ func (d decoder) decodeMapStringRawMessage(b []byte, p unsafe.Pointer) ([]byte, 
 
 		if i != 0 {
 			if len(b) == 0 {
-				return b, syntaxError(b, "unexpected EOF after object field value")
+				return b, syntaxError(b, "unexpected end of JSON input after object field value")
 			}
 			if b[0] != ',' {
 				return b, syntaxError(b, "expected ',' after object field value but found '%c'", b[0])
@@ -727,14 +851,18 @@ func (d decoder) decodeMapStringRawMessage(b []byte, p unsafe.Pointer) ([]byte, 
 			b = skipSpaces(b[1:])
 		}
 
+		if hasPrefix(b, "null") {
+			return b, syntaxError(b, "cannot decode object key string from 'null' value")
+		}
+
 		b, err = d.decodeString(b, unsafe.Pointer(&key))
 		if err != nil {
-			return b, err
+			return objectKeyError(b, err)
 		}
 		b = skipSpaces(b)
 
 		if len(b) == 0 {
-			return b, syntaxError(b, "unexpected EOF after object field key")
+			return b, syntaxError(b, "unexpected end of JSON input after object field key")
 		}
 		if b[0] != ':' {
 			return b, syntaxError(b, "expected ':' after object field key but found '%c'", b[0])
@@ -743,6 +871,11 @@ func (d decoder) decodeMapStringRawMessage(b []byte, p unsafe.Pointer) ([]byte, 
 
 		b, err = d.decodeRawMessage(b, unsafe.Pointer(&val))
 		if err != nil {
+			if _, r, err := parseValue(input); err != nil {
+				return r, err
+			} else {
+				b = r
+			}
 			if e, ok := err.(*UnmarshalTypeError); ok {
 				e.Struct = mapStringRawMessageType.String() + e.Struct
 				e.Field = key + "." + e.Field
@@ -756,13 +889,13 @@ func (d decoder) decodeMapStringRawMessage(b []byte, p unsafe.Pointer) ([]byte, 
 }
 
 func (d decoder) decodeStruct(b []byte, p unsafe.Pointer, st *structType) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		return b[4:], nil
 	}
+
 	if len(b) < 2 || b[0] != '{' {
-		return b, unmarshalTypeError(b, st.typ)
+		return inputError(b, st.typ)
 	}
-	b = b[1:]
 
 	var err error
 	var k []byte
@@ -771,7 +904,9 @@ func (d decoder) decodeStruct(b []byte, p unsafe.Pointer, st *structType) ([]byt
 	// memory buffer used to convert short field names to lowercase
 	var buf [64]byte
 	var key []byte
+	var input = b
 
+	b = b[1:]
 	for {
 		b = skipSpaces(b)
 
@@ -781,7 +916,7 @@ func (d decoder) decodeStruct(b []byte, p unsafe.Pointer, st *structType) ([]byt
 
 		if i != 0 {
 			if len(b) == 0 {
-				return b, syntaxError(b, "unexpected EOF after object field value")
+				return b, syntaxError(b, "unexpected end of JSON input after object field value")
 			}
 			if b[0] != ',' {
 				return b, syntaxError(b, "expected ',' after object field value but found '%c'", b[0])
@@ -790,14 +925,18 @@ func (d decoder) decodeStruct(b []byte, p unsafe.Pointer, st *structType) ([]byt
 		}
 		i++
 
+		if hasPrefix(b, "null") {
+			return b, syntaxError(b, "cannot decode object key string from 'null' value")
+		}
+
 		k, b, _, err = parseStringUnquote(b, nil)
 		if err != nil {
-			return b, syntaxError(b, "parsing object field key: %s", err)
+			return objectKeyError(b, err)
 		}
 		b = skipSpaces(b)
 
 		if len(b) == 0 {
-			return b, syntaxError(b, "unexpected EOF after object field key")
+			return b, syntaxError(b, "unexpected end of JSON input after object field key")
 		}
 		if b[0] != ':' {
 			return b, syntaxError(b, "expected ':' after object field key but found '%c'", b[0])
@@ -822,6 +961,11 @@ func (d decoder) decodeStruct(b []byte, p unsafe.Pointer, st *structType) ([]byt
 		}
 
 		if b, err = f.codec.decode(d, b, unsafe.Pointer(uintptr(p)+f.offset)); err != nil {
+			if _, r, err := parseValue(input); err != nil {
+				return r, err
+			} else {
+				b = r
+			}
 			if e, ok := err.(*UnmarshalTypeError); ok {
 				e.Struct = st.typ.String() + e.Struct
 				e.Field = string(k) + "." + e.Field
@@ -836,7 +980,7 @@ func (d decoder) decodeEmbeddedStructPointer(b []byte, p unsafe.Pointer, t refle
 
 	if v == nil {
 		if unexported {
-			return b, fmt.Errorf("json: cannot set embedded pointer to unexported struct: %s", t)
+			return nil, fmt.Errorf("json: cannot set embedded pointer to unexported struct: %s", t)
 		}
 		v = unsafe.Pointer(reflect.New(t).Pointer())
 		*(*unsafe.Pointer)(p) = v
@@ -846,7 +990,7 @@ func (d decoder) decodeEmbeddedStructPointer(b []byte, p unsafe.Pointer, t refle
 }
 
 func (d decoder) decodePointer(b []byte, p unsafe.Pointer, t reflect.Type, decode decodeFunc) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		pp := *(*unsafe.Pointer)(p)
 		if pp != nil && t.Kind() == reflect.Ptr {
 			return decode(d, b, pp)
@@ -873,7 +1017,7 @@ func (d decoder) decodeInterface(b []byte, p unsafe.Pointer) ([]byte, error) {
 			// If the destination is nil the only value that is OK to decode is
 			// `null`, and the encoding/json package always nils the destination
 			// interface value in this case.
-			if hasPrefix(b, "null") {
+			if hasNullPrefix(b) {
 				*(*interface{})(p) = nil
 				return b[4:], nil
 			}
@@ -943,6 +1087,23 @@ func (d decoder) decodeInterface(b []byte, p unsafe.Pointer) ([]byte, error) {
 	return b, nil
 }
 
+func (d decoder) decodeMaybeEmptyInterface(b []byte, p unsafe.Pointer, t reflect.Type) ([]byte, error) {
+	if hasNullPrefix(b) {
+		*(*interface{})(p) = nil
+		return b[4:], nil
+	}
+
+	if x := reflect.NewAt(t, p).Elem(); !x.IsNil() {
+		if e := x.Elem(); e.Kind() == reflect.Ptr {
+			return Parse(b, e.Interface(), d.flags)
+		}
+	} else if t.NumMethod() == 0 { // empty interface
+		return Parse(b, (*interface{})(p), d.flags)
+	}
+
+	return d.decodeUnmarshalTypeError(b, p, t)
+}
+
 func (d decoder) decodeUnmarshalTypeError(b []byte, p unsafe.Pointer, t reflect.Type) ([]byte, error) {
 	v, b, err := parseValue(b)
 	if err != nil {
@@ -957,7 +1118,7 @@ func (d decoder) decodeUnmarshalTypeError(b []byte, p unsafe.Pointer, t reflect.
 func (d decoder) decodeRawMessage(b []byte, p unsafe.Pointer) ([]byte, error) {
 	v, r, err := parseValue(b)
 	if err != nil {
-		return r, unmarshalTypeError(b, rawMessageType)
+		return inputError(b, rawMessageType)
 	}
 
 	if (d.flags & DontCopyRawMessage) == 0 {
@@ -992,12 +1153,20 @@ func (d decoder) decodeJSONUnmarshaler(b []byte, p unsafe.Pointer, t reflect.Typ
 func (d decoder) decodeTextUnmarshaler(b []byte, p unsafe.Pointer, t reflect.Type, pointer bool) ([]byte, error) {
 	var value string
 
-	switch b[0] {
+	v, b, err := parseValue(b)
+	if err != nil {
+		return b, err
+	}
+	if len(v) == 0 {
+		return inputError(v, t)
+	}
+
+	switch v[0] {
 	case 'n':
-		_, b, err := parseNull(b)
+		_, _, err := parseNull(v)
 		return b, err
 	case '"':
-		s, b, _, err := parseStringUnquote(b, nil)
+		s, _, _, err := parseStringUnquote(v, nil)
 		if err != nil {
 			return b, err
 		}
@@ -1024,8 +1193,3 @@ func (d decoder) decodeTextUnmarshaler(b []byte, p unsafe.Pointer, t reflect.Typ
 
 	return b, &UnmarshalTypeError{Value: value, Type: reflect.PtrTo(t)}
 }
-
-var (
-	// This is a placeholder used to consturct non-nil empty slices.
-	empty struct{}
-)

--- a/vendor/github.com/segmentio/encoding/json/encode.go
+++ b/vendor/github.com/segmentio/encoding/json/encode.go
@@ -13,6 +13,8 @@ import (
 	"unsafe"
 )
 
+const hex = "0123456789abcdef"
+
 func (e encoder) encodeNull(b []byte, p unsafe.Pointer) ([]byte, error) {
 	return append(b, "null"...), nil
 }
@@ -77,8 +79,11 @@ func (e encoder) encodeFloat64(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (e encoder) encodeFloat(b []byte, f float64, bits int) ([]byte, error) {
-	if math.IsNaN(f) || math.IsInf(f, 0) {
-		return b, &UnsupportedValueError{Value: reflect.ValueOf(f), Str: "unsupported value"}
+	switch {
+	case math.IsNaN(f):
+		return b, &UnsupportedValueError{Value: reflect.ValueOf(f), Str: "NaN"}
+	case math.IsInf(f, 0):
+		return b, &UnsupportedValueError{Value: reflect.ValueOf(f), Str: "inf"}
 	}
 
 	// Convert as if by ES6 number to string conversion.
@@ -124,15 +129,12 @@ func (e encoder) encodeNumber(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (e encoder) encodeString(b []byte, p unsafe.Pointer) ([]byte, error) {
-	hex := "0123456789abcdef"
-
 	s := *(*string)(p)
 	i := 0
 	j := 0
+	escapeHTML := (e.flags & EscapeHTML) != 0
 
 	b = append(b, '"')
-
-	escapeHTML := (e.flags & EscapeHTML) != 0
 
 	for j < len(s) {
 		c := s[j]
@@ -235,8 +237,7 @@ func (e encoder) encodeToString(b []byte, p unsafe.Pointer, encode encodeFunc) (
 	}
 
 	j := len(b)
-	x := b[i:]
-	s := *(*string)(unsafe.Pointer(&x))
+	s := b[i:]
 
 	if b, err = e.encodeString(b, unsafe.Pointer(&s)); err != nil {
 		return b, err
@@ -527,6 +528,7 @@ func (e encoder) encodeMapStringRawMessage(b []byte, p unsafe.Pointer) ([]byte, 
 func (e encoder) encodeStruct(b []byte, p unsafe.Pointer, st *structType) ([]byte, error) {
 	var start = len(b)
 	var err error
+	var k string
 	var n int
 	b = append(b, '{')
 
@@ -542,13 +544,19 @@ func (e encoder) encodeStruct(b []byte, p unsafe.Pointer, st *structType) ([]byt
 			b = append(b, ',')
 		}
 
-		k := len(b)
-		b, _ = e.encodeString(b, unsafe.Pointer(&f.name))
+		if (e.flags & EscapeHTML) != 0 {
+			k = f.html
+		} else {
+			k = f.json
+		}
+
+		lengthBeforeKey := len(b)
+		b = append(b, k...)
 		b = append(b, ':')
 
 		if b, err = f.codec.encode(e, b, v); err != nil {
 			if err == (rollback{}) {
-				b = b[:k]
+				b = b[:lengthBeforeKey]
 				continue
 			}
 			return b[:start], err
@@ -584,7 +592,11 @@ func (e encoder) encodeInterface(b []byte, p unsafe.Pointer) ([]byte, error) {
 	return Append(b, *(*interface{})(p), e.flags)
 }
 
-func (e encoder) encodeUnsupportedType(b []byte, p unsafe.Pointer, t reflect.Type) ([]byte, error) {
+func (e encoder) encodeMaybeEmptyInterface(b []byte, p unsafe.Pointer, t reflect.Type) ([]byte, error) {
+	return Append(b, reflect.NewAt(t, p).Elem().Interface(), e.flags)
+}
+
+func (e encoder) encodeUnsupportedTypeError(b []byte, p unsafe.Pointer, t reflect.Type) ([]byte, error) {
 	return b, &UnsupportedTypeError{Type: t}
 }
 
@@ -595,9 +607,16 @@ func (e encoder) encodeRawMessage(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return append(b, "null"...), nil
 	}
 
-	s, _, err := parseValue(v)
-	if err != nil {
-		return b, &UnsupportedValueError{Value: reflect.ValueOf(v), Str: err.Error()}
+	var s []byte
+
+	if (e.flags & TrustRawMessage) != 0 {
+		s = v
+	} else {
+		var err error
+		s, _, err = parseValue(v)
+		if err != nil {
+			return b, &UnsupportedValueError{Value: reflect.ValueOf(v), Str: err.Error()}
+		}
 	}
 
 	if (e.flags & EscapeHTML) != 0 {
@@ -615,7 +634,7 @@ func (e encoder) encodeJSONMarshaler(b []byte, p unsafe.Pointer, t reflect.Type,
 	}
 
 	switch v.Kind() {
-	case reflect.Ptr, reflect.Map, reflect.Interface, reflect.Slice:
+	case reflect.Ptr, reflect.Interface:
 		if v.IsNil() {
 			return append(b, "null"...), nil
 		}
@@ -646,9 +665,9 @@ func (e encoder) encodeTextMarshaler(b []byte, p unsafe.Pointer, t reflect.Type,
 	}
 
 	switch v.Kind() {
-	case reflect.Ptr, reflect.Map, reflect.Interface, reflect.Slice:
+	case reflect.Ptr, reflect.Interface:
 		if v.IsNil() {
-			return append(b, `""`...), nil
+			return append(b, `null`...), nil
 		}
 	}
 
@@ -661,7 +680,6 @@ func (e encoder) encodeTextMarshaler(b []byte, p unsafe.Pointer, t reflect.Type,
 }
 
 func appendCompactEscapeHTML(dst []byte, src []byte) []byte {
-	const hex = "0123456789abcdef"
 	start := 0
 	escape := false
 	inString := false

--- a/vendor/github.com/segmentio/encoding/json/parse.go
+++ b/vendor/github.com/segmentio/encoding/json/parse.go
@@ -3,6 +3,7 @@ package json
 import (
 	"bytes"
 	"math"
+	"reflect"
 	"unicode"
 	"unicode/utf16"
 	"unicode/utf8"
@@ -16,8 +17,6 @@ const (
 	ht = '\t'
 	nl = '\n'
 	cr = '\r'
-	np = '\f'
-	bs = '\b'
 )
 
 const (
@@ -25,28 +24,20 @@ const (
 	quote  = '"'
 )
 
-// Constants used for the optimized string scanning functions. The values are
-// masks applied to test if a word contains a byte we're looking for.
-const (
-	escapeMask = uint64(escape<<56 | escape<<48 | escape<<40 | escape<<32 |
-		escape<<24 | escape<<16 | escape<<8 | escape)
-
-	quoteMask = uint64(quote<<56 | quote<<48 | quote<<40 | quote<<32 |
-		quote<<24 | quote<<16 | quote<<8 | quote)
-)
-
 func skipSpaces(b []byte) []byte {
-	i := 0
-skipLoop:
-	for _, c := range b {
-		switch c {
-		case sp, ht, nl, cr, np, bs:
-			i++
+	b, _ = skipSpacesN(b)
+	return b
+}
+
+func skipSpacesN(b []byte) ([]byte, int) {
+	for i := range b {
+		switch b[i] {
+		case sp, ht, nl, cr:
 		default:
-			break skipLoop
+			return b[i:], i
 		}
 	}
-	return b[i:]
+	return nil, 0
 }
 
 // parseInt parses a decimanl representation of an int64 from b.
@@ -57,7 +48,7 @@ skipLoop:
 //
 // Because it only works with base 10 the function is also significantly faster
 // than strconv.ParseInt.
-func parseInt(b []byte) (int64, []byte, error) {
+func parseInt(b []byte, t reflect.Type) (int64, []byte, error) {
 	var value int64
 	var count int
 
@@ -69,23 +60,32 @@ func parseInt(b []byte) (int64, []byte, error) {
 		const max = math.MinInt64
 		const lim = max / 10
 
+		if len(b) == 1 {
+			return 0, b, syntaxError(b, "cannot decode integer from '-'")
+		}
+
+		if len(b) > 2 && b[1] == '0' && '0' <= b[2] && b[2] <= '9' {
+			return 0, b, syntaxError(b, "invalid leading character '0' in integer")
+		}
+
 		for _, d := range b[1:] {
 			if !(d >= '0' && d <= '9') {
 				if count == 0 {
-					return 0, b, syntaxError(b, "missing digits after negative sign")
+					b, err := inputError(b, t)
+					return 0, b, err
 				}
 				break
 			}
 
 			if value < lim {
-				return 0, b, syntaxError(b, "integer value out of range")
+				return 0, b, unmarshalOverflow(b, t)
 			}
 
 			value *= 10
 			x := int64(d - '0')
 
 			if value < (max + x) {
-				return 0, b, syntaxError(b, "integer value out of range")
+				return 0, b, unmarshalOverflow(b, t)
 			}
 
 			value -= x
@@ -97,21 +97,26 @@ func parseInt(b []byte) (int64, []byte, error) {
 		const max = math.MaxInt64
 		const lim = max / 10
 
+		if len(b) > 1 && b[0] == '0' && '0' <= b[1] && b[1] <= '9' {
+			return 0, b, syntaxError(b, "invalid leading character '0' in integer")
+		}
+
 		for _, d := range b {
 			if !(d >= '0' && d <= '9') {
 				if count == 0 {
-					return 0, b, syntaxError(b, "expected digit but found '%c'", d)
+					b, err := inputError(b, t)
+					return 0, b, err
 				}
 				break
 			}
 			x := int64(d - '0')
 
 			if value > lim {
-				return 0, b, syntaxError(b, "integer value out of range")
+				return 0, b, unmarshalOverflow(b, t)
 			}
 
 			if value *= 10; value > (max - x) {
-				return 0, b, syntaxError(b, "integer value out of range")
+				return 0, b, unmarshalOverflow(b, t)
 			}
 
 			value += x
@@ -119,11 +124,22 @@ func parseInt(b []byte) (int64, []byte, error) {
 		}
 	}
 
+	if count < len(b) {
+		switch b[count] {
+		case '.', 'e', 'E': // was this actually a float?
+			v, r, err := parseNumber(b)
+			if err != nil {
+				v, r = b[:count+1], b[count+1:]
+			}
+			return 0, r, unmarshalTypeError(v, t)
+		}
+	}
+
 	return value, b[count:], nil
 }
 
 // parseUint is like parseInt but for unsigned integers.
-func parseUint(b []byte) (uint64, []byte, error) {
+func parseUint(b []byte, t reflect.Type) (uint64, []byte, error) {
 	const max = math.MaxUint64
 	const lim = max / 10
 
@@ -134,25 +150,41 @@ func parseUint(b []byte) (uint64, []byte, error) {
 		return 0, b, syntaxError(b, "cannot decode integer value from an empty input")
 	}
 
+	if len(b) > 1 && b[0] == '0' && '0' <= b[1] && b[1] <= '9' {
+		return 0, b, syntaxError(b, "invalid leading character '0' in integer")
+	}
+
 	for _, d := range b {
 		if !(d >= '0' && d <= '9') {
 			if count == 0 {
-				return 0, b, syntaxError(b, "expected digit but found '%c'", d)
+				b, err := inputError(b, t)
+				return 0, b, err
 			}
 			break
 		}
 		x := uint64(d - '0')
 
 		if value > lim {
-			return 0, b, syntaxError(b, "integer value out of range")
+			return 0, b, unmarshalOverflow(b, t)
 		}
 
 		if value *= 10; value > (max - x) {
-			return 0, b, syntaxError(b, "integer value out of range")
+			return 0, b, unmarshalOverflow(b, t)
 		}
 
 		value += x
 		count++
+	}
+
+	if count < len(b) {
+		switch b[count] {
+		case '.', 'e', 'E': // was this actually a float?
+			v, r, err := parseNumber(b)
+			if err != nil {
+				v, r = b[:count+1], b[count+1:]
+			}
+			return 0, r, unmarshalTypeError(v, t)
+		}
 	}
 
 	return value, b[count:], nil
@@ -217,12 +249,18 @@ func parseNull(b []byte) ([]byte, []byte, error) {
 	if hasNullPrefix(b) {
 		return b[:4], b[4:], nil
 	}
+	if len(b) < 4 {
+		return nil, b[len(b):], unexpectedEOF(b)
+	}
 	return nil, b, syntaxError(b, "expected 'null' but found invalid token")
 }
 
 func parseTrue(b []byte) ([]byte, []byte, error) {
 	if hasTruePrefix(b) {
 		return b[:4], b[4:], nil
+	}
+	if len(b) < 4 {
+		return nil, b[len(b):], unexpectedEOF(b)
 	}
 	return nil, b, syntaxError(b, "expected 'true' but found invalid token")
 }
@@ -231,106 +269,103 @@ func parseFalse(b []byte) ([]byte, []byte, error) {
 	if hasFalsePrefix(b) {
 		return b[:5], b[5:], nil
 	}
+	if len(b) < 5 {
+		return nil, b[len(b):], unexpectedEOF(b)
+	}
 	return nil, b, syntaxError(b, "expected 'false' but found invalid token")
 }
 
 func parseNumber(b []byte) (v, r []byte, err error) {
-	r = b
-
-	if len(r) == 0 {
-		err = syntaxError(b, "expected number but found no data")
+	if len(b) == 0 {
+		r, err = b, unexpectedEOF(b)
 		return
 	}
 
+	i := 0
 	// sign
-	if r[0] == '-' {
-		r = r[1:]
+	if b[i] == '-' {
+		i++
 	}
 
-	if len(r) == 0 {
-		err = syntaxError(b, "missing number value after sign")
+	if i == len(b) {
+		r, err = b[i:], syntaxError(b, "missing number value after sign")
+		return
+	}
+
+	if b[i] < '0' || b[i] > '9' {
+		r, err = b[i:], syntaxError(b, "expected digit but got '%c'", b[i])
 		return
 	}
 
 	// integer part
-	leadingZero := false
-	integerLength := 0
-
-	for i := 0; len(r) != 0; i++ {
-		c := r[0]
-
-		if i == 0 && c == '0' {
-			leadingZero = true
+	if b[i] == '0' {
+		i++
+		if i == len(b) || (b[i] != '.' && b[i] != 'e' && b[i] != 'E') {
+			v, r = b[:i], b[i:]
+			return
 		}
-
-		if !('0' <= c && c <= '9') {
-			if i == 0 {
-				err = syntaxError(b, "expected digit but found '%c'", c)
-				return
-			}
-			break
+		if '0' <= b[i] && b[i] <= '9' {
+			r, err = b[i:], syntaxError(b, "cannot decode number with leading '0' character")
+			return
 		}
-
-		r = r[1:]
-		integerLength++
 	}
 
-	if leadingZero && integerLength > 1 {
-		err = syntaxError(b, "unexpected leading zero in number")
-		return
+	for i < len(b) && '0' <= b[i] && b[i] <= '9' {
+		i++
 	}
 
 	// decimal part
-	if len(r) != 0 && r[0] == '.' {
-		decimalLength := 0
-		r = r[1:]
+	if i < len(b) && b[i] == '.' {
+		i++
+		decimalStart := i
 
-		for i := 0; len(r) != 0; i++ {
-			if c := r[0]; !('0' <= c && c <= '9') {
-				if i == 0 {
-					err = syntaxError(b, "expected digit but found '%c'", c)
+		for i < len(b) {
+			if c := b[i]; !('0' <= c && c <= '9') {
+				if i == decimalStart {
+					r, err = b[i:], syntaxError(b, "expected digit but found '%c'", c)
 					return
 				}
 				break
 			}
-			r = r[1:]
-			decimalLength++
+			i++
 		}
 
-		if decimalLength == 0 {
-			err = syntaxError(b, "expected decimal part after '.'")
+		if i == decimalStart {
+			r, err = b[i:], syntaxError(b, "expected decimal part after '.'")
 			return
 		}
 	}
 
 	// exponent part
-	if len(r) != 0 && (r[0] == 'e' || r[0] == 'E') {
-		r = r[1:]
+	if i < len(b) && (b[i] == 'e' || b[i] == 'E') {
+		i++
 
-		if len(r) != 0 {
-			if c := r[0]; c == '+' || c == '-' {
-				r = r[1:]
+		if i < len(b) {
+			if c := b[i]; c == '+' || c == '-' {
+				i++
 			}
 		}
 
-		if len(r) == 0 {
-			err = syntaxError(b, "missing exponent in number")
+		if i == len(b) {
+			r, err = b[i:], syntaxError(b, "missing exponent in number")
 			return
 		}
 
-		for i := 0; len(r) != 0; i++ {
-			if c := r[0]; !('0' <= c && c <= '9') {
-				if i == 0 {
+		exponentStart := i
+
+		for i < len(b) {
+			if c := b[i]; !('0' <= c && c <= '9') {
+				if i == exponentStart {
 					err = syntaxError(b, "expected digit but found '%c'", c)
 					return
 				}
 				break
 			}
-			r = r[1:]
+			i++
 		}
 	}
 
-	v = b[:len(b)-len(r)]
+	v, r = b[:i], b[i:]
 	return
 }
 
@@ -352,36 +387,49 @@ func parseUnicode(b []byte) (rune, int, error) {
 }
 
 func parseStringFast(b []byte) ([]byte, []byte, bool, error) {
-	if len(b) < 2 || b[0] != '"' {
+	if len(b) < 2 {
+		return nil, b[len(b):], false, unexpectedEOF(b)
+	}
+	if b[0] != '"' {
 		return nil, b, false, syntaxError(b, "expected '\"' at the beginning of a string value")
 	}
 
-	i := bytes.IndexByte(b[1:], '"')
-	if i >= 0 && i < len(b) {
-		if i++; bytes.IndexByte(b[1:i], '\\') < 0 && ascii.Valid(b[1:i]) {
-			return b[:i+1], b[i+1:], false, nil
-		}
+	n := bytes.IndexByte(b[1:], '"') + 2
+	if n <= 1 {
+		return nil, b[len(b):], false, syntaxError(b, "missing '\"' at the end of a string value")
+	}
+	if bytes.IndexByte(b[1:n], '\\') < 0 && ascii.ValidPrint(b[1:n]) {
+		return b[:n], b[n:], false, nil
 	}
 
-	offset := 1
+	for i := 1; i < len(b); i++ {
+		switch b[i] {
+		case '\\':
+			if i++; i < len(b) {
+				switch b[i] {
+				case '"', '\\', '/', 'n', 'r', 't', 'f', 'b':
+				case 'u':
+					_, n, err := parseUnicode(b[i+1:])
+					if err != nil {
+						return nil, b, false, err
+					}
+					i += n
+				default:
+					return nil, b, false, syntaxError(b, "invalid character '%c' in string escape code", b[i])
+				}
+			}
 
-	for offset < len(b) {
-		i := bytes.IndexByte(b[offset:], '"')
-		if i < 0 {
-			break
-		}
-		i += offset
-		j := bytes.IndexByte(b[offset:i], '\\')
-		if j < 0 {
+		case '"':
 			return b[:i+1], b[i+1:], true, nil
-		}
-		offset += j + 1
-		if offset < len(b) && b[offset] == '\\' || b[offset] == '"' {
-			offset++ // skip escaped sequence
+
+		default:
+			if b[i] < 0x20 {
+				return nil, b, false, syntaxError(b, "invalid character '%c' in string escape code", b[i])
+			}
 		}
 	}
 
-	return nil, b, false, syntaxError(b, "missing '\"' at the end of a string value")
+	return nil, b[len(b):], false, syntaxError(b, "missing '\"' at the end of a string value")
 }
 
 func parseString(b []byte) ([]byte, []byte, error) {
@@ -452,8 +500,6 @@ func parseStringUnquote(b []byte, r []byte) ([]byte, []byte, bool, error) {
 					if err != nil {
 						return r, b, true, err
 					}
-					i += n2
-
 					if r1 = utf16.DecodeRune(r1, r2); r1 != unicode.ReplacementChar {
 						s = s[2+n2:]
 					}
@@ -464,8 +510,7 @@ func parseStringUnquote(b []byte, r []byte) ([]byte, []byte, bool, error) {
 			continue
 
 		default: // not sure what this escape sequence is
-			r = append(r, '\\')
-			continue
+			return r, b, false, syntaxError(s, "invalid character '%c' in string escape code", c)
 		}
 
 		r = append(r, c)
@@ -492,7 +537,11 @@ func appendCoerceInvalidUTF8(b []byte, s []byte) []byte {
 }
 
 func parseObject(b []byte) ([]byte, []byte, error) {
-	if len(b) < 2 || b[0] != '{' {
+	if len(b) < 2 {
+		return nil, b[len(b):], unexpectedEOF(b)
+	}
+
+	if b[0] != '{' {
 		return nil, b, syntaxError(b, "expected '{' at the beginning of an object value")
 	}
 
@@ -522,6 +571,12 @@ func parseObject(b []byte) ([]byte, []byte, error) {
 				return nil, b, syntaxError(b, "expected ',' after object field value but found '%c'", b[0])
 			}
 			b = skipSpaces(b[1:])
+			if len(b) == 0 {
+				return nil, b, unexpectedEOF(b)
+			}
+			if b[0] == '}' {
+				return nil, b, syntaxError(b, "unexpected trailing comma after object field")
+			}
 		}
 
 		_, b, err = parseString(b)
@@ -548,7 +603,11 @@ func parseObject(b []byte) ([]byte, []byte, error) {
 }
 
 func parseArray(b []byte) ([]byte, []byte, error) {
-	if len(b) < 2 || b[0] != '[' {
+	if len(b) < 2 {
+		return nil, b[len(b):], unexpectedEOF(b)
+	}
+
+	if b[0] != '[' {
 		return nil, b, syntaxError(b, "expected '[' at the beginning of array value")
 	}
 
@@ -578,6 +637,12 @@ func parseArray(b []byte) ([]byte, []byte, error) {
 				return nil, b, syntaxError(b, "expected ',' after array element but found '%c'", b[0])
 			}
 			b = skipSpaces(b[1:])
+			if len(b) == 0 {
+				return nil, b, unexpectedEOF(b)
+			}
+			if b[0] == ']' {
+				return nil, b, syntaxError(b, "unexpected trailing comma after object field")
+			}
 		}
 
 		_, b, err = parseValue(b)
@@ -607,10 +672,10 @@ func parseValue(b []byte) ([]byte, []byte, error) {
 		case '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
 			return parseNumber(b)
 		default:
-			return nil, b, syntaxError(b, "expected token but found '%c'", b[0])
+			return nil, b, syntaxError(b, "invalid character '%c' looking for beginning of value", b[0])
 		}
 	}
-	return nil, b, syntaxError(b, "expected json but found no data")
+	return nil, b, syntaxError(b, "unexpected end of JSON input")
 }
 
 func hasNullPrefix(b []byte) bool {
@@ -627,6 +692,17 @@ func hasFalsePrefix(b []byte) bool {
 
 func hasPrefix(b []byte, s string) bool {
 	return len(b) >= len(s) && s == string(b[:len(s)])
+}
+
+func hasLeadingSign(b []byte) bool {
+	return len(b) > 0 && (b[0] == '+' || b[0] == '-')
+}
+
+func hasLeadingZeroes(b []byte) bool {
+	if hasLeadingSign(b) {
+		b = b[1:]
+	}
+	return len(b) > 1 && b[0] == '0' && '0' <= b[1] && b[1] <= '9'
 }
 
 func appendToLower(b, s []byte) []byte {

--- a/vendor/github.com/segmentio/encoding/json/reflect.go
+++ b/vendor/github.com/segmentio/encoding/json/reflect.go
@@ -1,0 +1,19 @@
+// +build go1.15
+
+package json
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+func extendSlice(t reflect.Type, s *slice, n int) slice {
+	arrayType := reflect.ArrayOf(n, t.Elem())
+	arrayData := reflect.New(arrayType)
+	reflect.Copy(arrayData.Elem(), reflect.NewAt(t, unsafe.Pointer(s)).Elem())
+	return slice{
+		data: unsafe.Pointer(arrayData.Pointer()),
+		len:  s.len,
+		cap:  n,
+	}
+}

--- a/vendor/github.com/segmentio/encoding/json/reflect_optimize.go
+++ b/vendor/github.com/segmentio/encoding/json/reflect_optimize.go
@@ -1,0 +1,29 @@
+// +build !go1.15
+
+package json
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+//go:linkname unsafe_NewArray reflect.unsafe_NewArray
+func unsafe_NewArray(rtype unsafe.Pointer, length int) unsafe.Pointer
+
+//go:linkname typedslicecopy reflect.typedslicecopy
+//go:noescape
+func typedslicecopy(elemType unsafe.Pointer, dst, src slice) int
+
+func extendSlice(t reflect.Type, s *slice, n int) slice {
+	elemTypeRef := t.Elem()
+	elemTypePtr := ((*iface)(unsafe.Pointer(&elemTypeRef))).ptr
+
+	d := slice{
+		data: unsafe_NewArray(elemTypePtr, n),
+		len:  s.len,
+		cap:  n,
+	}
+
+	typedslicecopy(elemTypePtr, d, *s)
+	return d
+}

--- a/vendor/github.com/segmentio/encoding/json/token.go
+++ b/vendor/github.com/segmentio/encoding/json/token.go
@@ -90,7 +90,7 @@ const (
 	inObject
 )
 
-// NeweTokenizer constructs a new Tokenizer which reads its json input from b.
+// NewTokenizer constructs a new Tokenizer which reads its json input from b.
 func NewTokenizer(b []byte) *Tokenizer { return &Tokenizer{json: b} }
 
 // Reset erases the state of t and re-initializes it with the json input from b.
@@ -129,7 +129,7 @@ func (t *Tokenizer) Next() bool {
 skipLoop:
 	for _, c := range t.json {
 		switch c {
-		case sp, ht, nl, cr, np, bs:
+		case sp, ht, nl, cr:
 			i++
 		default:
 			break skipLoop

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -65,7 +65,7 @@ github.com/pmezard/go-difflib/difflib
 github.com/pquerna/ffjson/ffjson
 github.com/pquerna/ffjson/fflib/v1
 github.com/pquerna/ffjson/fflib/v1/internal
-# github.com/segmentio/encoding v0.1.0
+# github.com/segmentio/encoding v0.1.14
 github.com/segmentio/encoding/ascii
 github.com/segmentio/encoding/json
 # github.com/stretchr/testify v1.4.0


### PR DESCRIPTION
✅ Tests pass

```
› go test ./ -run '/marshaller=(easyjson|segmentio-json)/' -count 1
ok  	github.com/narqo/benchserder	0.215s
```

⏲️ Benchmarks (before/after)

```
› benchcmp segmentio-json.bench.{1,2}
benchmark                                                                     old ns/op     new ns/op     delta
BenchmarkEvent_Marshal/marshaller=segmentio-json/file=event_2K.json-4         13771         9007          -34.59%
BenchmarkEvent_Marshal/marshaller=segmentio-json/file=event_5K.json-4         24810         18880         -23.90%
BenchmarkEvent_Marshal/marshaller=segmentio-json/file=event_10K.json-4        56761         43339         -23.65%
BenchmarkEvent_Marshal/marshaller=segmentio-json/file=event_50K.json-4        152439        150654        -1.17%
BenchmarkEvent_Marshal/marshaller=segmentio-json/file=event_100K.json-4       521837        443060        -15.10%
BenchmarkEvent_Marshal/marshaller=segmentio-json/file=event_225K.json-4       566372        583821        +3.08%
BenchmarkEvent_Unmarshal/marshaller=segmentio-json/file=event_2K.json-4       16426         16507         +0.49%
BenchmarkEvent_Unmarshal/marshaller=segmentio-json/file=event_5K.json-4       20554         20464         -0.44%
BenchmarkEvent_Unmarshal/marshaller=segmentio-json/file=event_10K.json-4      68768         74741         +8.69%
BenchmarkEvent_Unmarshal/marshaller=segmentio-json/file=event_50K.json-4      46704         45764         -2.01%
BenchmarkEvent_Unmarshal/marshaller=segmentio-json/file=event_100K.json-4     907885        871394        -4.02%
BenchmarkEvent_Unmarshal/marshaller=segmentio-json/file=event_225K.json-4     116358        119024        +2.29%

benchmark                                                                     old allocs     new allocs     delta
BenchmarkEvent_Marshal/marshaller=segmentio-json/file=event_2K.json-4         4              1              -75.00%
BenchmarkEvent_Marshal/marshaller=segmentio-json/file=event_5K.json-4         19             15             -21.05%
BenchmarkEvent_Marshal/marshaller=segmentio-json/file=event_10K.json-4        99             91             -8.08%
BenchmarkEvent_Marshal/marshaller=segmentio-json/file=event_50K.json-4        50             46             -8.00%
BenchmarkEvent_Marshal/marshaller=segmentio-json/file=event_100K.json-4       669            657            -1.79%
BenchmarkEvent_Marshal/marshaller=segmentio-json/file=event_225K.json-4       50             46             -8.00%
BenchmarkEvent_Unmarshal/marshaller=segmentio-json/file=event_2K.json-4       37             37             +0.00%
BenchmarkEvent_Unmarshal/marshaller=segmentio-json/file=event_5K.json-4       54             54             +0.00%
BenchmarkEvent_Unmarshal/marshaller=segmentio-json/file=event_10K.json-4      137            137            +0.00%
BenchmarkEvent_Unmarshal/marshaller=segmentio-json/file=event_50K.json-4      86             86             +0.00%
BenchmarkEvent_Unmarshal/marshaller=segmentio-json/file=event_100K.json-4     806            806            +0.00%
BenchmarkEvent_Unmarshal/marshaller=segmentio-json/file=event_225K.json-4     87             87             +0.00%

benchmark                                                                     old bytes     new bytes     delta
BenchmarkEvent_Marshal/marshaller=segmentio-json/file=event_2K.json-4         9216          3072          -66.67%
BenchmarkEvent_Marshal/marshaller=segmentio-json/file=event_5K.json-4         16512         7041          -57.36%
BenchmarkEvent_Marshal/marshaller=segmentio-json/file=event_10K.json-4        54880         13539         -75.33%
BenchmarkEvent_Marshal/marshaller=segmentio-json/file=event_50K.json-4        68016         58816         -13.53%
BenchmarkEvent_Marshal/marshaller=segmentio-json/file=event_100K.json-4       497792        125459        -74.80%
BenchmarkEvent_Marshal/marshaller=segmentio-json/file=event_225K.json-4       240048        230991        -3.77%
BenchmarkEvent_Unmarshal/marshaller=segmentio-json/file=event_2K.json-4       352           352           +0.00%
BenchmarkEvent_Unmarshal/marshaller=segmentio-json/file=event_5K.json-4       3872          3872          +0.00%
BenchmarkEvent_Unmarshal/marshaller=segmentio-json/file=event_10K.json-4      14096         14096         +0.00%
BenchmarkEvent_Unmarshal/marshaller=segmentio-json/file=event_50K.json-4      58416         58416         +0.00%
BenchmarkEvent_Unmarshal/marshaller=segmentio-json/file=event_100K.json-4     110753        110750        -0.00%
BenchmarkEvent_Unmarshal/marshaller=segmentio-json/file=event_225K.json-4     230513        230513        +0.00%
```

🏁 Benchmarks (`encoding/json` vs `easyjson` vs `segmentio/encoding`)

```
› go test ./ -run XX -bench 'shal/marshaller=(json$|easyjson|segmentio-json)/'
goos: darwin
goarch: amd64
pkg: github.com/narqo/benchserder
BenchmarkEvent_Marshal/marshaller=json/file=event_2K.json-4         	   63186	     18164 ns/op	    3889 B/op	      18 allocs/op
BenchmarkEvent_Marshal/marshaller=json/file=event_5K.json-4         	   43382	     27216 ns/op	    8003 B/op	      34 allocs/op
BenchmarkEvent_Marshal/marshaller=json/file=event_10K.json-4        	   22831	     50735 ns/op	   16052 B/op	     110 allocs/op
BenchmarkEvent_Marshal/marshaller=json/file=event_50K.json-4        	    9400	    130660 ns/op	   60347 B/op	      66 allocs/op
BenchmarkEvent_Marshal/marshaller=json/file=event_100K.json-4       	    2462	    466206 ns/op	  139519 B/op	     676 allocs/op
BenchmarkEvent_Marshal/marshaller=json/file=event_225K.json-4       	    2654	    456686 ns/op	  232617 B/op	      66 allocs/op
BenchmarkEvent_Marshal/marshaller=easyjson/file=event_2K.json-4     	  123112	      9428 ns/op	    3651 B/op	      25 allocs/op
BenchmarkEvent_Marshal/marshaller=easyjson/file=event_5K.json-4     	   59280	     19771 ns/op	    7789 B/op	      26 allocs/op
BenchmarkEvent_Marshal/marshaller=easyjson/file=event_10K.json-4    	   33567	     35222 ns/op	   11938 B/op	      27 allocs/op
BenchmarkEvent_Marshal/marshaller=easyjson/file=event_50K.json-4    	    7471	    165086 ns/op	   59562 B/op	      29 allocs/op
BenchmarkEvent_Marshal/marshaller=easyjson/file=event_100K.json-4   	    2498	    468536 ns/op	  109642 B/op	      32 allocs/op
BenchmarkEvent_Marshal/marshaller=easyjson/file=event_225K.json-4   	    1784	    663610 ns/op	  233859 B/op	      36 allocs/op
BenchmarkEvent_Marshal/marshaller=segmentio-json/file=event_2K.json-4         	  127774	      8963 ns/op	    3072 B/op	       1 allocs/op
BenchmarkEvent_Marshal/marshaller=segmentio-json/file=event_5K.json-4         	   62672	     18901 ns/op	    7041 B/op	      15 allocs/op
BenchmarkEvent_Marshal/marshaller=segmentio-json/file=event_10K.json-4        	   27224	     43547 ns/op	   13539 B/op	      91 allocs/op
BenchmarkEvent_Marshal/marshaller=segmentio-json/file=event_50K.json-4        	    8152	    151888 ns/op	   58816 B/op	      46 allocs/op
BenchmarkEvent_Marshal/marshaller=segmentio-json/file=event_100K.json-4       	    2589	    443578 ns/op	  125642 B/op	     657 allocs/op
BenchmarkEvent_Marshal/marshaller=segmentio-json/file=event_225K.json-4       	    2001	    584072 ns/op	  230986 B/op	      46 allocs/op
BenchmarkEvent_Unmarshal/marshaller=json/file=event_2K.json-4                 	   26013	     45849 ns/op	    1312 B/op	      68 allocs/op
BenchmarkEvent_Unmarshal/marshaller=json/file=event_5K.json-4                 	   16951	     70115 ns/op	    4960 B/op	      90 allocs/op
BenchmarkEvent_Unmarshal/marshaller=json/file=event_10K.json-4                	    9133	    133693 ns/op	   18288 B/op	     278 allocs/op
BenchmarkEvent_Unmarshal/marshaller=json/file=event_50K.json-4                	    3176	    354632 ns/op	   60321 B/op	     159 allocs/op
BenchmarkEvent_Unmarshal/marshaller=json/file=event_100K.json-4               	    1084	   1071389 ns/op	  208630 B/op	    1987 allocs/op
BenchmarkEvent_Unmarshal/marshaller=json/file=event_225K.json-4               	     936	   1270591 ns/op	  232419 B/op	     160 allocs/op
BenchmarkEvent_Unmarshal/marshaller=easyjson/file=event_2K.json-4             	   93727	     12852 ns/op	    1024 B/op	      55 allocs/op
BenchmarkEvent_Unmarshal/marshaller=easyjson/file=event_5K.json-4             	   62652	     18661 ns/op	    5152 B/op	      72 allocs/op
BenchmarkEvent_Unmarshal/marshaller=easyjson/file=event_10K.json-4            	   30850	     38497 ns/op	   19148 B/op	     150 allocs/op
BenchmarkEvent_Unmarshal/marshaller=easyjson/file=event_50K.json-4            	   15558	     76951 ns/op	   60593 B/op	     105 allocs/op
BenchmarkEvent_Unmarshal/marshaller=easyjson/file=event_100K.json-4           	    2695	    424764 ns/op	  216471 B/op	    1031 allocs/op
BenchmarkEvent_Unmarshal/marshaller=easyjson/file=event_225K.json-4           	    4647	    249494 ns/op	  232673 B/op	     106 allocs/op
BenchmarkEvent_Unmarshal/marshaller=segmentio-json/file=event_2K.json-4       	   71614	     16472 ns/op	     352 B/op	      37 allocs/op
BenchmarkEvent_Unmarshal/marshaller=segmentio-json/file=event_5K.json-4       	   56056	     20630 ns/op	    3872 B/op	      54 allocs/op
BenchmarkEvent_Unmarshal/marshaller=segmentio-json/file=event_10K.json-4      	   15722	     75743 ns/op	   14096 B/op	     137 allocs/op
BenchmarkEvent_Unmarshal/marshaller=segmentio-json/file=event_50K.json-4      	   24726	     47990 ns/op	   58416 B/op	      86 allocs/op
BenchmarkEvent_Unmarshal/marshaller=segmentio-json/file=event_100K.json-4     	    1324	    877018 ns/op	  110751 B/op	     806 allocs/op
BenchmarkEvent_Unmarshal/marshaller=segmentio-json/file=event_225K.json-4     	   10000	    118834 ns/op	  230513 B/op	      87 allocs/op
PASS
ok  	github.com/narqo/benchserder	51.369s
```